### PR TITLE
fix bugs with the URL function.

### DIFF
--- a/src/attr.js
+++ b/src/attr.js
@@ -42,7 +42,7 @@ Snap.plugin(function (Snap, Element, Paper, glob, Fragment) {
                 id: mask.id
             });
             $(this.node, {
-                mask: URL(mask.id)
+                mask: Snap.url(mask.id)
             });
         }
     });
@@ -63,7 +63,7 @@ Snap.plugin(function (Snap, Element, Paper, glob, Fragment) {
                 });
             }
             $(this.node, {
-                "clip-path": URL(clip.node.id || clip.id)
+                "clip-path": Snap.url(clip.node.id || clip.id)
             });
         }
     }));
@@ -86,7 +86,7 @@ Snap.plugin(function (Snap, Element, Paper, glob, Fragment) {
                             id: value.id
                         });
                     }
-                    var fill = URL(value.node.id);
+                    var fill = Snap.url(value.node.id);
                 } else {
                     fill = value.attr(name);
                 }
@@ -100,7 +100,7 @@ Snap.plugin(function (Snap, Element, Paper, glob, Fragment) {
                                 id: grad.id
                             });
                         }
-                        fill = URL(grad.node.id);
+                        fill = Snap.url(grad.node.id);
                     } else {
                         fill = value;
                     }
@@ -323,7 +323,7 @@ Snap.plugin(function (Snap, Element, Paper, glob, Fragment) {
                     if (!id) {
                         $(value.node, {id: value.id});
                     }
-                    this.node.style[name] = URL(id);
+                    this.node.style[name] = Snap.url(id);
                     return;
                 }
             };

--- a/src/element.js
+++ b/src/element.js
@@ -487,7 +487,7 @@ Snap.plugin(function (Snap, Element, Paper, glob, Fragment) {
             if (val) {
                 uses[val] = (uses[val] || []).concat(function (id) {
                     var attr = {};
-                    attr[name] = URL(id);
+                    attr[name] = Snap.url(id);
                     $(it.node, attr);
                 });
             }


### PR DESCRIPTION
Error is : Constructor URL requires 'new'.
See this for more informations : https://github.com/adobe-webplatform/Snap.svg/issues/390